### PR TITLE
Fix quoting / command injection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -101,7 +101,7 @@ export default {
 
         if (item.textField && item.selected) {
           if(item.text.length >= 2){
-            installstr.push(item.param + " '" + item.text + "'")
+            installstr.push(item.param + " '" + item.text.toString().replace(/\'/g, "'\\''") + "'")
           }
         } else if(!item.textField) {
           if (item.param.includes("force")) {


### PR DESCRIPTION
Previous version was vulnerable to command injection, for example if I set my password to
```
foo'$(id)'bar
```
the actual command would become
```
sudo bash hst-install.sh --password 'foo'$(id)'bar' 
```
and the actual password would become:
>foouid=1002(hans) gid=1002(hans) groups=1002(hans),4(adm),20(dialout),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev),100(users),107(netdev)bar

but with this the command becomes
```
sudo bash hst-install.sh --password 'foo'\''$(id)'\''bar' 
```
and the password becomes literally
```
foo'$(id)'bar
```